### PR TITLE
Fix flyout close button position

### DIFF
--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -1368,8 +1368,8 @@ BlockSvg.prototype.placeToFront = function () {
     this.tempRootDiv.style.position = 'absolute'
     this.tempRootDiv.style.top = `${blockClientRect.top - flyoutClientRect.top}px`
     this.tempRootDiv.style.left = `${blockClientRect.left - workspaceClientRect.left}px`
-    this.tempRootDiv.style.background = '#ddd'
-    this.tempRootDiv.style.boxShadow = '0 0 5px #ddd'
+    this.tempRootDiv.style.background = '#ccc'
+    this.tempRootDiv.style.boxShadow = '0 0 5px #ccc'
 
     const tempSVGRoot = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
     tempSVGRoot.setAttribute('width', `${blockClientRect.width}px`)

--- a/core/css.js
+++ b/core/css.js
@@ -439,8 +439,7 @@ let content = (`
   }
 
   .blocklyFlyoutBackground {
-    fill: #ddd;
-    fill-opacity: .8;
+    fill: #eee;
   }
 
   .blocklyMainWorkspaceScrollbar {
@@ -449,6 +448,22 @@ let content = (`
 
   .blocklyFlyoutScrollbar {
     z-index: 30;
+  }
+  
+  .blocklyFlyoutCloseButton {
+    position: absolute;
+    z-index: 20;
+    width: 30px;
+    height: 40px;
+    cursor: pointer;
+  }
+  
+  .blocklyFlyoutEndShadow {
+    display: block;
+    position: absolute;
+    width: 10px;
+    background-color: #eee;
+    z-index: 21;
   }
 
   .blocklyScrollbarHorizontal,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "varwin-blockly",
-  "version": "7.20211209.7",
+  "version": "7.20211209.8",
   "description": "Varwin Blockly it is a fork of Google Blockly for Varwin XRMS",
   "keywords": [
     "blockly",

--- a/scripts/gulpfiles/build_tasks.js
+++ b/scripts/gulpfiles/build_tasks.js
@@ -220,14 +220,8 @@ function buildDeps(done) {
     'tests/mocha'
   ];
 
-  // Use the code for build /tests/deps.js what used in build
-  // 
-  // const args = roots.map(root => `--root '${root}' `).join('');
-  // execSync(`closure-make-deps ${args} > tests/deps.js`, {stdio: 'inherit'});
-
-  // Use grep to filter out the entries that are already in deps.js.
-  // const testArgs = testRoots.map(root => `--root '${root}' `).join('');
-  // execSync(`closure-make-deps ${testArgs} | grep 'tests/mocha' > tests/deps.mocha.js`, {stdio: 'inherit'});
+  const args = roots.map(root => `--root '${root}' `).join('');
+  execSync(`closure-make-deps ${args} > tests/deps.js`, {stdio: 'inherit'});
 
   done();
 };
@@ -564,9 +558,9 @@ function buildAdvancedCompilationTest() {
  *     test/deps*.js
  */
 const build = gulp.parallel(
-    gulp.series(buildDeps, buildCompiled),
+    buildCompiled,
     buildLangfiles,
-    );
+);
 
 /**
  * This task copies built files from BUILD_DIR back to the repository


### PR DESCRIPTION
1. The flyout close button is now a standalone SVG that is inserted into the `injectionDiv` after the Flyout and placed next to it.
2. Added a half-line along the right edge of the Flyout, as Anton suggested, so that the blocks are not cut off so sharply
3. Removed transparency from the Flyout, but left it a tone lighter than the Toolbox to make it more pleasant to distinguish objects in the Flyout