### PR TITLE
Mass operations fixes

### DIFF
--- a/core/mass_operations/mass_operation_handlers.js
+++ b/core/mass_operations/mass_operation_handlers.js
@@ -434,7 +434,7 @@ MassOperationsHandler.prototype.selectAll = function () {
   if (selected) selected.unselect();
 
   this.workspace_.getAllBlocks().forEach(block => {
-    this.addBlockToSelected(block)
+    if (block.inActiveModule()) this.addBlockToSelected(block)
   })
 }
 

--- a/core/mass_operations/mass_operation_handlers.js
+++ b/core/mass_operations/mass_operation_handlers.js
@@ -222,6 +222,11 @@ MassOperationsHandler.prototype.blockMouseUp = function (block, e) {
 MassOperationsHandler.prototype.handleUp_ = function (e) {
   if (!browserEvents.isLeftButton(e)) return
 
+  if (this.blockDraggers_) {
+    this.blockDraggers_.forEach(dragger => dragger.endDrag(e, this.currentDragDeltaXY_));
+    this.blockDraggers_ = null
+  }
+
   this.cleanUp()
 }
 
@@ -394,11 +399,6 @@ MassOperationsHandler.prototype.cleanUp = function () {
   if (this.selectedBlocks_.length) {
     this.selectedBlocks_.forEach(block => block.removeSelectAsMassSelection());
     this.selectedBlocks_ = [];
-  }
-
-  if (this.blockDraggers_) {
-    this.blockDraggers_.forEach(dragger => dragger.endDrag(e, this.currentDragDeltaXY_));
-    this.blockDraggers_ = null
   }
 
   this.lastMouseDownBlock_ = null;

--- a/core/renderers/common/constants.js
+++ b/core/renderers/common/constants.js
@@ -1293,7 +1293,7 @@ ConstantProvider.prototype.getCSS_ = function(selector) {
 
     // Mass selection highlight.
     selector + ' .blocklyMassSelected {',
-    'outline: dashed 2px #3cf;',
+    'outline: dashed 4px #ffcc33;',
     '}',
 
     // Connection highlight.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "varwin-blockly",
-  "version": "7.20211209.12",
+  "version": "7.20211209.13",
   "description": "Varwin Blockly it is a fork of Google Blockly for Varwin XRMS",
   "keywords": [
     "blockly",


### PR DESCRIPTION
https://varwin.atlassian.net/browse/VRWN-5118

Исправления:
- цвет группового выделения - использовать цвет стандартного выделения + увеличить ширину до 4px
- Ctrl+A выделяет все объекты. Надо выделять только блоки активного модуля.
- Баг окончания D&D